### PR TITLE
changing value to match solutions

### DIFF
--- a/index.ipynb
+++ b/index.ipynb
@@ -248,7 +248,7 @@
     "- P(Antarctica) = 0.000\n",
     "- P(Asia) = 0.598\n",
     "- P(Europe) = 0.10\n",
-    "- P(North-America) = 0.078\n",
+    "- P(North-America) = 0.079\n",
     "- P(Australia) = 0.005\n",
     "- P(South-America) = 0.057"
    ]
@@ -731,7 +731,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.6.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Students commented that the p(north_america) = 0.078 in the index.ipynb does not match the solutions. na = 0.078